### PR TITLE
import format-to-string from format

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -20,4 +20,6 @@ define module %json
   use json;
   use streams;
   use strings;
+  use format,
+    import: { format-to-string };
 end;


### PR DESCRIPTION
Reference to undefined binding "format-to-string" in %json (parser.dylan), use the function available in the format module.