### PR TITLE
Give parse-json a table-class: parameter

### DIFF
--- a/tests/json-test-suite.dylan
+++ b/tests/json-test-suite.dylan
@@ -7,6 +7,9 @@ License: See License.txt in this distribution for details.
 
 // TODO(cgay): intentional parse errors.
 
+// Enables the #raw:(...) string syntax.
+define function raw-parser (s :: <string>) => (_ :: <string>) s end;
+
 define macro make-object
     { make-object(?rest:*) }
  => { make-table(<string-table>, ?rest); }
@@ -15,14 +18,14 @@ end;
 
 define test test-parse-object ()
   check-equal("a", parse-json("{}"), make-object());
-  check-equal("b", parse-json("{\"a\": 1}"), make-object("a" => 1));
-  check-equal("c", parse-json("{\"a\": true,\"b\": false, \"c\": null}"),
+  check-equal("b", parse-json(#raw:({"a": 1})), make-object("a" => 1));
+  check-equal("c", parse-json(#raw:({"a": true,"b": false, "c": null})),
               make-object("a" => #t, "b" => #f, "c" => $null));
   check-equal("Trailing comma allowed in non-strict mode?",
-              parse-json("{\"a\": true,}", strict?: #f),
+              parse-json(#raw:({"a": true,}), strict?: #f),
               make-object("a" => #t));
-  check-condition("Trailing comma allowed in non-strict mode?",
-                  <json-error>, parse-json("{\"a\": true,}"));
+  check-condition("Trailing comma is error in strict mode?",
+                  <json-error>, parse-json(#raw:({"a": true,})));
 end test test-parse-object;
 
 define test test-parse-array ()
@@ -31,14 +34,14 @@ define test test-parse-array ()
   check-equal("Trailing comma allowed in non-strict mode?",
               parse-json("[null,]", strict?: #f),
               vector($null));
-  check-condition("Trailing comma disallowed in strict mode?",
+  check-condition("Trailing comma is error in strict mode?",
                   <json-error>, parse-json("[null,true,false,]"))
 end test test-parse-array;
 
 define test test-parse-string ()
-  check-equal("a", parse-json("\"foo\""), "foo");
-  check-equal("b", parse-json("\"foo\\nbar\""), "foo\nbar");
-  check-equal("c", parse-json("\"\\\"\\\\\\/\\b\\f\\n\\r\\t\""), "\"\\/\b\f\n\r\t");
+  check-equal("a", parse-json(#raw:("foo")), "foo");
+  check-equal("b", parse-json(#raw:("foo\nbar")), "foo\nbar");
+  check-equal("c", parse-json(#raw:("\"\\/\b\f\n\r\t")), "\"\\/\b\f\n\r\t");
 end test test-parse-string;
 
 define test test-parse-number ()

--- a/tests/json-test-suite.dylan
+++ b/tests/json-test-suite.dylan
@@ -80,6 +80,12 @@ define test test-parse-whitespace ()
   check-equal("a", parse-json(" {\n\"key\"\r:\r\n123\r }"), obj);
 end test test-parse-whitespace;
 
+define test test-table-class ()
+  assert-equal(2, size(parse-json(#raw:({"a": 1, "A": 2}))));
+  assert-equal(1, size(parse-json(#raw:({"a": 1, "A": 2}),
+                                  table-class: <istring-table>)));
+end;
+
 define suite parser-test-suite ()
   test test-parse-object;
   test test-parse-array;
@@ -87,6 +93,7 @@ define suite parser-test-suite ()
   test test-parse-number;
   test test-parse-constants;
   test test-parse-whitespace;
+  test test-table-class;
 end suite parser-test-suite;
 
 define suite json-test-suite ()

--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -19,7 +19,8 @@ define module json-test-suite
   use common-dylan;
   use table-extensions,
     import: {},
-    rename: { table => make-table };
+    rename: { table => make-table,
+              <case-insensitive-string-table> => <istring-table> };
   use json;
   use format;
   use locators,


### PR DESCRIPTION
I want this so that in some tests I can parse json into an `<ordered-table>` for ease of comparison.